### PR TITLE
draft: watch out for script files that fail

### DIFF
--- a/tool.rkt
+++ b/tool.rkt
@@ -239,12 +239,16 @@ It should then be very fast to load.
                     (time-info
                      (string-append "Loading file " (path->string f))
                      ; Catch problems and display them in a message-box.
-                     (with-error-message-box
+                     (let ((maybe-props
+                       (with-error-message-box
                          (format "Error in script file ~s:\n" (path->string f))
                        (define props-list (get-property-dicts f))
                        ; Keep only the scripts that match the current os type.
                        (filter (λ (props) (memq this-os-type (prop-dict-ref props 'os-types)))
                                props-list))))
+                       (if (list? maybe-props)
+                         maybe-props
+                         '()))))
                   (user-script-files))))
              ;; Sort the menu items lexicographically.
              (set! property-dicts


### PR DESCRIPTION
Makes sure an `append-map` function always returns lists.

Before, `with-error-message-box` was returning the symbol `'ok`

- - -

I ran into this after copying all the quickscript competition scripts into my `user-scripts/` folder instead of installing the package.

That gave me a few script files with missing dependencies; for example `preview-markdown.rkt` depends on the `markdown` package.

When I tried to open DrRacket, an error would eventually say that `append` got `'ok` and DrRacket would not start.

- - -

This PR is mostly to explain the problem. No worries if you want to close it & fix things in a different way .... maybe `with-error-message-box` should take a "default" result.
