### PR TITLE
unbreak expand-time expression

### DIFF
--- a/script.rkt
+++ b/script.rkt
@@ -139,7 +139,7 @@
      #:fail-when (and (not (memq (syntax-e #'proc)
                                  known-hook-ids))
                       #'proc)
-     (string-append (string-constant qs-invalid-hook) known-hook-ids-str)
+     (string-append "Invalid hook name.\n Valid names:\n" known-hook-ids-str)
      (add-submod-content!
       #`(begin
           (provide proc)


### PR DESCRIPTION
Revert a part of bc7e121ee0 that used `string-constant` in a for-syntax context without a for-syntax require. It may be that using `string-constants` for-syntax is ok, but I'm not sure, so I'll let someone else follow up.